### PR TITLE
Use sha256 instead of sha1

### DIFF
--- a/make.go
+++ b/make.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"log"
@@ -17,10 +17,10 @@ class Peco < Formula
   homepage 'https://github.com/peco/peco'
   if OS.mac?
     url "https://github.com/peco/peco/releases/download/v#{HOMEBREW_PECO_VERSION}/peco_darwin_amd64.zip"
-    sha1 "%x"
+    sha256 "%x"
   elsif OS.linux?
     url "https://github.com/peco/peco/releases/download/v#{HOMEBREW_PECO_VERSION}/peco_linux_amd64.tar.gz"
-    sha1 "%x"
+    sha256 "%x"
   end
 
   version HOMEBREW_PECO_VERSION
@@ -54,10 +54,10 @@ class Migemogrep < Formula
   homepage 'https://github.com/peco/migemogrep'
   if OS.mac?
     url "https://github.com/peco/migemogrep/releases/download/v#{HOMEBREW_MIGEMOGREP_VERSION}/migemogrep_darwin_amd64.zip"
-    sha1 "%x"
+    sha256 "%x"
   elsif OS.linux?
     url "https://github.com/peco/migemogrep/releases/download/v#{HOMEBREW_MIGEMOGREP_VERSION}/migemogrep_linux_amd64.tar.gz"
-    sha1 "%x"
+    sha256 "%x"
   end
 
   version HOMEBREW_MIGEMOGREP_VERSION
@@ -112,7 +112,7 @@ func updateMigemogrepRb(version string) int {
 	return updateGenericRb("migemogrep", version, migemogrepRbFmt)
 }
 
-func fetchSha1(url string) (sum []byte, err error) {
+func fetchsha256(url string) (sum []byte, err error) {
 	log.Printf("Fetching url %s...", url)
 	res, err := http.Get(url)
 	if err != nil {
@@ -125,7 +125,7 @@ func fetchSha1(url string) (sum []byte, err error) {
 		return nil, err
 	}
 
-	h := sha1.New()
+	h := sha256.New()
 	io.Copy(h, res.Body)
 	return h.Sum(nil), nil
 }
@@ -140,7 +140,7 @@ func updateGenericRb(target, version, template string) int {
 	var err error
 
 	for i, u := range url {
-		if sum[i], err = fetchSha1(fmt.Sprintf(u, target, version, target)); err != nil {
+		if sum[i], err = fetchsha256(fmt.Sprintf(u, target, version, target)); err != nil {
 			return 1
 		}
 	}

--- a/migemogrep.rb
+++ b/migemogrep.rb
@@ -6,10 +6,10 @@ class Migemogrep < Formula
   homepage 'https://github.com/peco/migemogrep'
   if OS.mac?
     url "https://github.com/peco/migemogrep/releases/download/v#{HOMEBREW_MIGEMOGREP_VERSION}/migemogrep_darwin_amd64.zip"
-    sha1 "d565035fe29e92858ba4b4393d36a1f338758b6b"
+    sha256 "5b6eefbfbc2c6f89693988a17b96d4355b297dbe1cf8d517dd8d620d74fc0d51"
   elsif OS.linux?
     url "https://github.com/peco/migemogrep/releases/download/v#{HOMEBREW_MIGEMOGREP_VERSION}/migemogrep_linux_amd64.tar.gz"
-    sha1 "2f95ffb8c440ccfa9bf2e35a83f5e79aceb36985"
+    sha256 "db1fe734036b12e89644d73ea94e47983899c100ae6a154107ef912163a603fe"
   end
 
   version HOMEBREW_MIGEMOGREP_VERSION

--- a/peco.rb
+++ b/peco.rb
@@ -6,10 +6,10 @@ class Peco < Formula
   homepage 'https://github.com/peco/peco'
   if OS.mac?
     url "https://github.com/peco/peco/releases/download/v#{HOMEBREW_PECO_VERSION}/peco_darwin_amd64.zip"
-    sha1 "fd35ea116c20b2ad8fd4935d0b0a0b1f4019ef7c"
+    sha256 "7d2c56202f9b1273cd03b351e41e8a472c3b8bff9450a807ef77dc4e261dcb70"
   elsif OS.linux?
     url "https://github.com/peco/peco/releases/download/v#{HOMEBREW_PECO_VERSION}/peco_linux_amd64.tar.gz"
-    sha1 "e450acc3781139ebef3c25b1229abb3c052fd6b3"
+    sha256 "90728c44afbf63fe38cbdc54f6953c2d4187844288fb9a85f1ecd5c273e4ec94"
   end
 
   version HOMEBREW_PECO_VERSION

--- a/peco.rb
+++ b/peco.rb
@@ -1,15 +1,15 @@
 # WARNING: Automatically generated. All changes to this file will be lost
 require 'formula'
 
-HOMEBREW_PECO_VERSION='0.3.3'
+HOMEBREW_PECO_VERSION='0.3.6'
 class Peco < Formula
   homepage 'https://github.com/peco/peco'
   if OS.mac?
     url "https://github.com/peco/peco/releases/download/v#{HOMEBREW_PECO_VERSION}/peco_darwin_amd64.zip"
-    sha256 "7d2c56202f9b1273cd03b351e41e8a472c3b8bff9450a807ef77dc4e261dcb70"
+    sha256 "bec6be871d09ec15a1bb9fff3c6df548be30203beb5e07134af479c05ef50fac"
   elsif OS.linux?
     url "https://github.com/peco/peco/releases/download/v#{HOMEBREW_PECO_VERSION}/peco_linux_amd64.tar.gz"
-    sha256 "90728c44afbf63fe38cbdc54f6953c2d4187844288fb9a85f1ecd5c273e4ec94"
+    sha256 "f8b045bcaefbf4ffeee70b4ab2fc49263666f2d61f0b31a9ac2094870b8b3918"
   end
 
   version HOMEBREW_PECO_VERSION


### PR DESCRIPTION
for migemogrep

migemogrepの方でWarningが出てたので修正しました。